### PR TITLE
Support daemon installs

### DIFF
--- a/conf.d/nix-env.fish
+++ b/conf.d/nix-env.fish
@@ -1,5 +1,8 @@
 # Setup Nix
 set -l nix_profile_path ~/.nix-profile/etc/profile.d/nix.sh
+if test ! -e $nix_profile_path
+  set nix_profile_path /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+end
 if test -e $nix_profile_path
   # Source the nix setup script
   # We're going to run the regular Nix profile under bash and then print out a few variables


### PR DESCRIPTION
I'm still new to nix, so this may be nonsensical, but having installed nix via `sh <(curl https://nixos.org/nix/install) --daemon`, I don't have a ` ~/.nix-profile/etc/profile.d/nix.sh`.

Would something like this make sense?   (Or, being the daemon profile script, maybe it goes against the grain to have it in here rather than `/etc/fish/config.fish` ?)