### PR TITLE
Update fisher command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Any Fish package manager should be able to install this.
 ### [Fisher](https://github.com/jorgebucaran/fisher)
 
 ```fish
-fisher add lilyball/nix-env.fish
+fisher install lilyball/nix-env.fish
 ```
 
 ### Manual install


### PR DESCRIPTION
Not sure about past versions, but for the current version of fisher @ 4.2.0 there is no `add` subcommand, only `install`.