### PR TITLE
Use command to avoid aliases/builtins

### DIFF
--- a/conf.d/nix-env.fish
+++ b/conf.d/nix-env.fish
@@ -22,7 +22,7 @@ if test -e $nix_profile_path
   # the wrong user.
 
   # stat is not portable. Splitting the output of ls -nd is reliable on most platforms.
-  set -l owner (string split -n ' ' (ls -nd /nix/store 2>/dev/null))[3]
+  set -l owner (string split -n ' ' (command ls -nd /nix/store 2>/dev/null))[3]
   if not test -k /nix/store -a $owner -eq 0
     # /nix/store is either not owned by root or not sticky. Assume single-user.
     set nix_profile_path $single_user_profile_path
@@ -35,7 +35,7 @@ end
 if test -e $nix_profile_path
   # Source the nix setup script
   # We're going to run the regular Nix profile under bash and then print out a few variables
-  for line in (env -u BASH_ENV bash -c '. "$0"; for name in PATH "${!NIX_@}"; do printf "%s=%s\0" "$name" "${!name}"; done' $nix_profile_path | string split0)
+  for line in (command env -u BASH_ENV bash -c '. "$0"; for name in PATH "${!NIX_@}"; do printf "%s=%s\0" "$name" "${!name}"; done' $nix_profile_path | string split0)
     set -xg (string split -m 1 = $line)
   end
 


### PR DESCRIPTION
Hi! Firstly, thanks for publishing this, it's great!

When getting it running locally, I ran into an issue where I had https://github.com/garabik/grc installed which aliases things like `ls` and `env`, causing the nix-env.fish script to error out.

This PR uses fish's `command` (https://fishshell.com/docs/current/cmds/command.html) for the `ls` and `env` call so that aliases/builtins are completely ignored.